### PR TITLE
Add support for ethernet capable Mellanox adapters to FreeNAS 9.10

### DIFF
--- a/build/profiles/freenas9/kernel/FREENAS.amd64
+++ b/build/profiles/freenas9/kernel/FREENAS.amd64
@@ -79,6 +79,7 @@ options 	RACCT			# Resource accounting framework
 options 	RACCT_DEFAULT_TO_DISABLED # Set kern.racct.enable=0 by default
 options 	RCTL			# Resource limits
 options 	KGSSAPI
+options		OFED			# Required for Mellanox adapter support
 
 # Debugging support.  Always need this:
 options 	KDB			# Enable kernel debugger support.
@@ -213,6 +214,9 @@ device		ixv			# Intel PRO/10GbE PCIE VF Ethernet
 device		ixl			# Intel XL710 40Gbe PCIE Ethernet
 device		ixlv			# Intel XL710 40Gbe VF PCIE Ethernet
 device		le			# AMD Am7900 LANCE and Am79C9xx PCnet
+device		mlxen			# Mellanox ConnectX, ConnectX-2, ConnectX-3 Series
+device		mlx5			# Mellanox ConnectX-4 common code
+device		mlx5en			# Mellanox ConnectX-4 Series
 device		mxge			# Myricom Myri10GE 10 Gigabit Ethernet adapter driver
 device		ti			# Alteon Networks Tigon I/II gigabit Ethernet
 device		txp			# 3Com 3cR990 (``Typhoon'')


### PR DESCRIPTION
- ConnectX and later series will work

Note - Infinihost series adapters (and older) won't work,
as they don't support ethernet mode.
