### PR TITLE
ticket #14512: Include Midnight Commander in FreeNAS

### DIFF
--- a/build/profiles/freenas9/ports-system.pyd
+++ b/build/profiles/freenas9/ports-system.pyd
@@ -446,6 +446,7 @@ ports += "security/pam_google_authenticator"
 ports += "benchmarks/fio"
 ports += "sysutils/htop"
 ports += "sysutils/mcelog"
+ports += "misc/mc"
 if PRODUCT == "TrueNAS":
     ports += "www/grafana2"
 


### PR DESCRIPTION
I have added "mc" port inside /build/profiles/freenas9/ports-system.pyd and Midnight Commander is included.
