### PR TITLE
Mitigate detached head checkout

### DIFF
--- a/build/profiles/freenas10/ports-middleware.pyd
+++ b/build/profiles/freenas10/ports-middleware.pyd
@@ -166,15 +166,6 @@ ports += {
 }
 
 ports += {
-    "name": "freenas/freenas-migrate93",
-    "options": [
-        "PRODUCT_VERSION=${VERSION}",
-        "BUILD_TIMESTAMP=${BUILD_TIMESTAMP}",
-        "REVISION=" + middleware_git_rev
-    ]
-}
-
-ports += {
     "name": "freenas/freenas-debug",
     "options": [
         "PRODUCT_VERSION=${VERSION}",
@@ -290,7 +281,7 @@ ports += {
 dedicated_repo_ports = [
     "py-freenas.cli", "py-freenas.utils", "py-libzfs", "py-netif", "py-cam", "py-SMART", "py-ws4py", "py-dhcp",
     "py-bsd", "py-smbconf", "py-pf", "py-wbclient", "py-krb5", "py-dockerhub", "licenselib", "py-ipfs-api",
-    "py-msock", "freenas-pkgtools", "py-filewrap"
+    "py-msock", "freenas-pkgtools", "py-filewrap", "freenas-migrate93"
 ]
 
 for iter_port in dedicated_repo_ports:

--- a/build/profiles/freenas10/repos.pyd
+++ b/build/profiles/freenas10/repos.pyd
@@ -257,9 +257,8 @@ repos += {
 repos += {
     "name": "django1611",
     "path": "django1611",
-    "url": "https://github.com/django/django",
-    "branch": "stable/1.6.x",
-    "commit": "9d915ac"
+    "url": "https://github.com/freenas/django",
+    "branch": "stable/1.6.11"
 }
 
 if PRODUCT == "TrueNAS":


### PR DESCRIPTION
This makes it so that there is no special case of a commit hash based checkout in the freenas10 build.

This also allows SHALLOW GIT CHECKOUTS feature to work again.

Tested to build and boot up as of yesterday night (14th Jan, 2017)