### PR TITLE
Updating FreeBSD revision number that is known to build FN-9.10 these days.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The steps below are the short summary version.
 ## Requirements
 
 * Operating System
-  * For building FreeNAS 9.10 (only), your build environment must be FreeBSD 11-STABLE #0 r309771 or later.
+  * For building FreeNAS 9.10 (only), your build environment must be FreeBSD 11-STABLE r309771 or later.
   * For building FreeNAS 10, your build environment must be FreeBSD 11.0-RELEASE or later.
 
 * Free space

--- a/README.md
+++ b/README.md
@@ -9,10 +9,8 @@ The steps below are the short summary version.
 ## Requirements
 
 * Operating System
-  * For building FreeNAS 9.10 (only), your build environment must be FreeBSD 11-STABLE #0 r313553
-    or later.
-  * For building FreeNAS 10, your build environment must be FreeBSD 11.0-RELEASE or
-    later.
+  * For building FreeNAS 9.10 (only), your build environment must be FreeBSD 11-STABLE #0 r309771 or later.
+  * For building FreeNAS 10, your build environment must be FreeBSD 11.0-RELEASE or later.
 
 * Free space
   * For building on a ZFS based system, you must have ~140GB space free.


### PR DESCRIPTION
Updating document to say "FreeBSD 11-STABLE #0 r309771". Thanks, @Spearfoot, for verifying.