### PR TITLE
Remove validation script that prevents 9.x --> 10 upgrades.

### DIFF
--- a/build/profiles/freenas10/ValidateUpdate
+++ b/build/profiles/freenas10/ValidateUpdate
@@ -1,8 +1,0 @@
-#!/bin/sh
-
-case "${CURRENT_VERSION}" 
-in
-	FreeNAS-9.*) echo "Cannot yet upgrade from FreeNAS 9.x to FreeNAS 10" 1>&2 ; exit 1 ;;
-esac
-exit 0
-


### PR DESCRIPTION
Have tested this with a custom build, seems to work for me, doing another round of verification by not directly committing this and making it a PR to be approved by Sean.


Ticket: #19560