### PR TITLE
Add logic to nuke freenasUI files and left out dojo files in both pos…

### DIFF
--- a/build/profiles/freenas10/packages/freenasUI/config
+++ b/build/profiles/freenas10/packages/freenasUI/config
@@ -20,17 +20,13 @@ include = @include(filelist)
 # Fresh installs don't need this.
 # However, if the package name changed, we would.
 
-#post-install = 
-#	if [ -f /data/freenas-v1.db ]; then
-#	   /usr/bin/touch /data/cd-upgrade
-#	   /usr/bin/touch /data/need-update
-#	fi
-#	test -f /data/freenas-v1.db && \
-#		/usr/bin/yes | /usr/local/bin/python \
-#		            /usr/local/www/freenasUI/manage.py migrate --all --merge --delete-ghost-migrations
-
-post-upgrade = 
+post-install =
 	rm -rf /usr/local/www/freenasUI
+	rm -rf /usr/local/www/dojo
+
+post-upgrade =
+	rm -rf /usr/local/www/freenasUI
+	rm -rf /usr/local/www/dojo
 
 [Services]
 


### PR DESCRIPTION
…t-install as well as post-upgrade hooks.

fn9 has the package named freeNASUI and fn10 has it named as freenasui so this results in fn9's being
deleted then fn10's being installed intead of an upgrade.

Ticket: #19560